### PR TITLE
Added overloads with string interpolation

### DIFF
--- a/Eshava.Storm.Tests/Eshava.Storm.Tests.csproj
+++ b/Eshava.Storm.Tests/Eshava.Storm.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="MSTest.Sdk/3.6.1">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <!--
+      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
+      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
+      -->
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="8.3.0" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Eshava.Storm\Eshava.Storm.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Eshava.Storm.Tests/MSTestSettings.cs
+++ b/Eshava.Storm.Tests/MSTestSettings.cs
@@ -1,0 +1,3 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/Eshava.Storm.Tests/SqlInterpolatedStringHandlerTests.cs
+++ b/Eshava.Storm.Tests/SqlInterpolatedStringHandlerTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Linq;
+using Eshava.Storm.Handler;
+using Eshava.Storm.MetaData;
+using Eshava.Storm.MetaData.Builders;
+using Eshava.Storm.MetaData.Interfaces;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Eshava.Storm.Tests
+{
+	[TestClass]
+	public sealed class SqlInterpolatedStringHandlerTests
+	{
+		[AssemblyInitialize]
+		public static void AssemblyInitialize(TestContext context)
+		{
+			TypeAnalyzer.AddType(new AlphaDbConfiguation());
+		}
+
+		[TestMethod]
+		public void BasicTest()
+		{
+			var searchString = "A search string";
+
+			SqlInterpolatedStringHandler sqlInterpolatedStringHandler = $"""
+				SELECT
+					alpha.*
+				FROM
+					{TypeAnalyzer.GetTableName<Alpha>()} alpha
+				WHERE
+					alpha.{nameof(Alpha.Description)} = @{searchString}
+				ORDER BY
+					{nameof(Alpha.Id)} desc
+				""";
+
+			var query = sqlInterpolatedStringHandler.ToStringAndClear();
+			var parameters = sqlInterpolatedStringHandler.Parameters;
+
+			query.Should().Contain("[alphaScheme].[Alphas] alpha");
+
+			parameters.Should().HaveCount(1);
+			parameters.First().Value.Should().Be(searchString);
+		}
+
+		private class Alpha
+		{
+			public int Id { get; set; }
+			public bool HasSomething { get; set; }
+			public string Description { get; set; }
+			public DateTime ChangedAtUtc { get; set; }
+		}
+
+		private class AlphaDbConfiguation : IEntityTypeConfiguration<Alpha>
+		{
+			public void Configure(EntityTypeBuilder<Alpha> builder)
+			{
+				builder.HasKey(x => x.Id);
+				builder.ToTable("Alphas", "alphaScheme");
+			}
+		}
+	}
+}

--- a/Eshava.Storm.sln
+++ b/Eshava.Storm.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30309.148
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35527.113 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eshava.Storm", "Eshava.Storm\Eshava.Storm.csproj", "{21ADB094-508B-4CD5-BAB6-387FF02D80D8}"
 EndProject
@@ -14,6 +14,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eshava.Storm.Linq", "Eshava.Storm.Linq\Eshava.Storm.Linq.csproj", "{5C15BB24-B439-4227-BF9A-DB04E8EC031D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eshava.Storm.Linq.Tests", "Eshava.Storm.Linq.Tests\Eshava.Storm.Linq.Tests.csproj", "{1CB3BE01-38B5-4835-8EB0-635EED1B9FFE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eshava.Storm.Tests", "Eshava.Storm.Tests\Eshava.Storm.Tests.csproj", "{C33ABB1C-C949-46E7-89B6-56B7882390F0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{1CB3BE01-38B5-4835-8EB0-635EED1B9FFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1CB3BE01-38B5-4835-8EB0-635EED1B9FFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1CB3BE01-38B5-4835-8EB0-635EED1B9FFE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C33ABB1C-C949-46E7-89B6-56B7882390F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C33ABB1C-C949-46E7-89B6-56B7882390F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C33ABB1C-C949-46E7-89B6-56B7882390F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C33ABB1C-C949-46E7-89B6-56B7882390F0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Eshava.Storm/Eshava.Storm.csproj
+++ b/Eshava.Storm/Eshava.Storm.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 		<LangVersion>latest</LangVersion>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <Version>1.0.0</Version>
 		<PackageProjectUrl>https://github.com/eshava/storm</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
@@ -11,6 +11,7 @@
 		<Description>A simple tentaculated object-relational mapper for .Net</Description>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Eshava.Storm/Extensions/IDbConnectionExtensions.Query.cs
+++ b/Eshava.Storm/Extensions/IDbConnectionExtensions.Query.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
 using Eshava.Storm.Engines;
+using Eshava.Storm.Handler;
 using Eshava.Storm.Interfaces;
 using Eshava.Storm.Models;
 
@@ -22,7 +23,6 @@ namespace Eshava.Storm
 				commandType,
 				cancellationToken);
 
-
 			return new SqlEngine().QueryAsync<T>(commandDefinition, null);
 		}
 
@@ -37,10 +37,8 @@ namespace Eshava.Storm
 				commandType,
 				cancellationToken);
 
-
 			return new SqlEngine().QueryAsync(commandDefinition, map);
 		}
-
 
 		public static Task<T> QueryFirstOrDefaultAsync<T>(this IDbConnection connection, string sql, object parameter = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
 		{
@@ -52,7 +50,6 @@ namespace Eshava.Storm
 				commandTimeout,
 				commandType,
 				cancellationToken);
-
 
 			return new SqlEngine().QueryFirstOrDefaultAsync<T>(commandDefinition, null);
 		}
@@ -70,7 +67,6 @@ namespace Eshava.Storm
 
 			return new SqlEngine().QueryFirstOrDefaultAsync(commandDefinition, map);
 		}
-
 
 		public static Task<T> ExecuteScalarAsync<T>(this IDbConnection connection, string sql, object parameter = null, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
 		{
@@ -99,5 +95,109 @@ namespace Eshava.Storm
 
 			return new SqlEngine().ExecuteAsync(commandDefinition);
 		}
+
+#if NET6_0_OR_GREATER
+		public static Task<IEnumerable<T>> QueryAsync<T>(this IDbConnection connection, ref SqlInterpolatedStringHandler handler, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
+		{
+			var sql = handler.ToStringAndClear();
+			var parameter = handler.Parameters;
+
+			var commandDefinition = new CommandDefinition(
+				connection,
+				sql,
+				parameter,
+				transaction,
+				commandTimeout,
+				commandType,
+				cancellationToken);
+
+			return new SqlEngine().QueryAsync<T>(commandDefinition, null);
+		}
+
+		public static Task<IEnumerable<T>> QueryAsync<T>(this IDbConnection connection, ref SqlInterpolatedStringHandler handler, Func<IObjectMapper, T> map, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
+		{
+			var sql = handler.ToStringAndClear();
+			var parameter = handler.Parameters;
+
+			var commandDefinition = new CommandDefinition(
+				connection,
+				sql,
+				parameter,
+				transaction,
+				commandTimeout,
+				commandType,
+				cancellationToken);
+
+			return new SqlEngine().QueryAsync(commandDefinition, map);
+		}
+
+		public static Task<T> QueryFirstOrDefaultAsync<T>(this IDbConnection connection, ref SqlInterpolatedStringHandler handler, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
+		{
+			var sql = handler.ToStringAndClear();
+			var parameter = handler.Parameters;
+
+			var commandDefinition = new CommandDefinition(
+				connection,
+				sql,
+				parameter,
+				transaction,
+				commandTimeout,
+				commandType,
+				cancellationToken);
+
+			return new SqlEngine().QueryFirstOrDefaultAsync<T>(commandDefinition, null);
+		}
+
+		public static Task<T> QueryFirstOrDefaultAsync<T>(this IDbConnection connection, ref SqlInterpolatedStringHandler handler, Func<IObjectMapper, T> map, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
+		{
+			var sql = handler.ToStringAndClear();
+			var parameter = handler.Parameters;
+
+			var commandDefinition = new CommandDefinition(
+				connection,
+				sql,
+				parameter,
+				transaction,
+				commandTimeout,
+				commandType,
+				cancellationToken);
+
+			return new SqlEngine().QueryFirstOrDefaultAsync(commandDefinition, map);
+		}
+
+		public static Task<T> ExecuteScalarAsync<T>(this IDbConnection connection, ref SqlInterpolatedStringHandler handler, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
+		{
+			var sql = handler.ToStringAndClear();
+			var parameter = handler.Parameters;
+
+			var commandDefinition = new CommandDefinition(
+				connection,
+				sql,
+				parameter,
+				transaction,
+				commandTimeout,
+				commandType,
+				cancellationToken);
+
+			return new SqlEngine().ExecuteScalarAsync<T>(commandDefinition);
+		}
+
+		public static Task<int> ExecuteAsync(this IDbConnection connection, ref SqlInterpolatedStringHandler handler, IDbTransaction transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
+		{
+			var sql = handler.ToStringAndClear();
+			var parameter = handler.Parameters;
+
+			var commandDefinition = new CommandDefinition(
+				connection,
+				sql,
+				parameter,
+				transaction,
+				commandTimeout,
+				commandType,
+				cancellationToken);
+
+			return new SqlEngine().ExecuteAsync(commandDefinition);
+		}
+#endif
 	}
 }

--- a/Eshava.Storm/Handler/SqlInterpolatedStringHandler.cs
+++ b/Eshava.Storm/Handler/SqlInterpolatedStringHandler.cs
@@ -1,0 +1,56 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Runtime.CompilerServices;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Eshava.Storm.Handler
+{
+
+	[InterpolatedStringHandler]
+	public ref struct SqlInterpolatedStringHandler
+	{
+		private DefaultInterpolatedStringHandler _innerHandler;
+		private Dictionary<string, object> _parameters;
+		private string _prefix;
+		private bool _hasAtSymbol;
+
+		public readonly IReadOnlyDictionary<string, object> Parameters => new ReadOnlyDictionary<string, object>(_parameters);
+
+		public SqlInterpolatedStringHandler(int literalLength, int formattedCount)
+		{
+			_parameters = new Dictionary<string, object>(formattedCount);
+			_innerHandler = new DefaultInterpolatedStringHandler(literalLength, formattedCount);
+			_prefix = Guid.NewGuid().ToString()[..4];
+		}
+
+		public void AppendLiteral(string literal)
+		{
+			_innerHandler.AppendLiteral(literal);
+			_hasAtSymbol = literal.Last() == '@';
+		}
+
+		public void AppendFormatted<T>(T value)
+		{
+			if (_hasAtSymbol)
+			{
+				var paramName = _prefix + "_" + (_parameters.Count + 1).ToString();
+
+				_parameters.Add(paramName, value);
+				_innerHandler.AppendLiteral(paramName);
+				_hasAtSymbol = false;
+			}
+			else
+			{
+				_innerHandler.AppendLiteral(value?.ToString());
+			}
+		}
+
+		public string ToStringAndClear() => _innerHandler.ToStringAndClear();
+		public override string ToString() => _innerHandler.ToString();
+	}
+}
+
+#endif


### PR DESCRIPTION
Added string-interpolation handler SqlInterpolatedStringHandler overloads to IDbConnection Extensions.
It allows to get rid of the "object parameter" parameter.

How to use:

```csharp
	SqlInterpolatedStringHandler sql = $"""
		SELECT
			alpha.*
		FROM
			{TypeAnalyzer.GetTableName<Alpha>()} alpha
		WHERE
			alpha.{nameof(Alpha.Description)} = @{searchString}
		ORDER BY
			{nameof(Alpha.Id)} desc
		""";
	var result = connection.QueryAsync<Alpha>(sql);
```

Internally it captures the given values following an "@" into a parameters dictionary which is then provided to the sql engine